### PR TITLE
Separates stop and skip to handle different events

### DIFF
--- a/src/components/CopilotModal.js
+++ b/src/components/CopilotModal.js
@@ -203,6 +203,11 @@ class CopilotModal extends Component<Props, State> {
     this.props.stop();
   }
 
+  handleSkip = () => {
+    this.reset();
+    this.props.skip();
+  }
+
   renderMask() {
     /* eslint-disable global-require */
     const MaskComponent = this.props.overlay === 'svg'
@@ -238,6 +243,7 @@ class CopilotModal extends Component<Props, State> {
           handleNext={this.handleNext}
           handlePrev={this.handlePrev}
           handleStop={this.handleStop}
+          handleSkip={this.handleSkip}
         />
       </Animated.View>,
     ];

--- a/src/hocs/copilot.js
+++ b/src/hocs/copilot.js
@@ -154,6 +154,11 @@ const copilot = ({
         this.eventEmitter.emit('stop');
       }
 
+      skip = async (): void => {
+        await this.setVisibility(false);
+        this.eventEmitter.emit('skip');
+      }
+
       startScroll = async (targetMeasure): void => {
         const whereToScroll =
           targetMeasure.y -
@@ -206,6 +211,7 @@ const copilot = ({
               next={this.next}
               prev={this.prev}
               stop={this.stop}
+              skip={this.skip}
               visible={this.state.visible}
               isFirstStep={this.isFirstStep()}
               isLastStep={this.isLastStep()}


### PR DESCRIPTION
Adds a skip prop to separate between stopping (Ending a tour in a screen) and skipping (Avoid launching the complete tour again)